### PR TITLE
VCFv4.1 -> 4.2

### DIFF
--- a/23andme2vcf.pl
+++ b/23andme2vcf.pl
@@ -30,7 +30,7 @@ my $output_fh = IO::File->new(">$output_path");
 my $missing_ref_fh = -1;
 
 #print the header for the VCF
-print $output_fh "##fileformat=VCFv4.1\n";
+print $output_fh "##fileformat=VCFv4.2\n";
 print $output_fh "##fileDate=$date\n";
 print $output_fh "##source=23andme2vcf.pl https://github.com/arrogantrobot/23andme2vcf\n";
 print $output_fh "##reference=file://$ref_path\n";


### PR DESCRIPTION
The most current VCF specification is VCF 4.2 (http://www.1000genomes.org/wiki/analysis/variant%20call%20format/vcf-variant-call-format-version-41). When the version in the VCF header is changed to 4.2, the generated VCF file is still syntactically valid according to vcf-validator.